### PR TITLE
prevent ios from capitalizing username on login

### DIFF
--- a/src/app/templates/views/login.tpl.html
+++ b/src/app/templates/views/login.tpl.html
@@ -14,7 +14,8 @@
             <div class="alert alert-danger" id="error521" ng-if="error">{{ error.message }}</div>
             <div class="form-group">
                 <input 
-                autocomplete="off" 
+                autocomplete="off"
+                autocapitalize="none"
                 type="text" 
                 ng-model="username" 
                 class="form-control dark" 


### PR DESCRIPTION
Apple docs https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/Attributes.html#//apple_ref/doc/uid/TP40008058-autocapitalize

This has bugged me since 2 launched.