### PR TITLE
Fix wobbly spinner

### DIFF
--- a/src/sass/sidebar.scss
+++ b/src/sass/sidebar.scss
@@ -82,8 +82,8 @@ body {
                     .fa-repeat {
                         float: right;
                         display: block;
-                        line-height: ($sidebarRowHeight - 4 - $sidebarReduction);
-                        height: ($sidebarRowHeight - 4 - $sidebarReduction);
+                        line-height: 100%;
+                        height: ($sidebarRowHeight - 2 - $sidebarReduction);
                         margin-right: 15px;
                         position: absolute;
                         right: 0;


### PR DESCRIPTION
Adjusting the `line-height` to the font size seems to do the trick for me. I also adjusted the `height` so that the icon is aligned vertically with the text. I have only tested this in Safari and Chromium through the web inspector. #26 