### PR TITLE
Composer perf

### DIFF
--- a/src/app/controllers/compose.js
+++ b/src/app/controllers/compose.js
@@ -609,6 +609,8 @@ angular.module("proton.controllers.Compose", ["proton.constants"])
         var composers = $('.composer'),
             environment = function() {
                 
+                if(composers.lenght === 0){ return; }
+
                 var set = {};
 
                 set.composerWidth   = composers.eq(0).outerWidth();

--- a/src/app/controllers/compose.js
+++ b/src/app/controllers/compose.js
@@ -622,7 +622,7 @@ angular.module("proton.controllers.Compose", ["proton.constants"])
                 /*
                 Is the available space enough ?
                 */
-                if(!set.isBootstrap && ((set.windowWidth / set.messagesCount) < set.composerWidth) ){
+                if(!set.isBootstrap && ((set.windowWidth / set.messagesCount) < (set.composerWidth + set.margin)) ){
                 /* 
                 overlap is a ratio that will share equaly the space 
                 available between overlayed composers. 
@@ -665,7 +665,7 @@ angular.module("proton.controllers.Compose", ["proton.constants"])
                         overlap = c.overlap;
                         
                         /* */
-                        styles.right =  (overlap) ? (index*overlap) :  (index * (composerWidth) + (2*margin)),
+                        styles.right =  (overlap) ? (index*overlap) :  ((index * (composerWidth+margin)) + margin),
                         styles.top = '';  
                 }
 

--- a/src/app/controllers/compose.js
+++ b/src/app/controllers/compose.js
@@ -467,7 +467,8 @@ angular.module("proton.controllers.Compose", ["proton.constants"])
         message.Attachments.push(tempPacket);
         message.attachmentsToggle = true;
 
-        $scope.composerStyle();
+        // $scope.composerStyle(); /*depreciated*/
+
         $rootScope.$broadcast('composerModeChange');
 
         var cleanup = function( result ) {
@@ -609,21 +610,28 @@ angular.module("proton.controllers.Compose", ["proton.constants"])
             environment = function() {
                 
                 var set = {};
+
                 set.composerWidth   = composers.eq(0).outerWidth();
                 set.margin          = ($('html').hasClass('ua-windows_nt')) ? 40 : 20;
                 set.windowWidth     = $('body').outerWidth();
                 set.messagesCount   = $scope.messages.length;
                 set.isBootstrap     = (tools.findBootstrapEnvironment() === 'xs') ? true : false;
 
+                /*
+                Is the available space enough ?
+                */
                 if(!set.isBootstrap && ((set.windowWidth / set.messagesCount) < set.composerWidth) ){
                 /* 
-                overlap is a ratio that will share the space available between overlayed composers. 
+                overlap is a ratio that will share equaly the space 
+                available between overlayed composers. 
                 */
                    set.overlap = ( (set.windowWidth - set.composerWidth - (2*set.margin)) / (set.messagesCount-1) );                
                 }
 
                 return set;
             },
+
+            /* used as _ context */
             context = environment();
 
 
@@ -637,14 +645,14 @@ angular.module("proton.controllers.Compose", ["proton.constants"])
                 styles.top = top + 'px';
 
             }else{
-                    
+                
                 var c = this,
                     messagesCount = c.messagesCount,
                     margin = c.margin,
                     isCurrent = ((messagesCount - index) === messagesCount) ? true : false;
 
                 if (isCurrent) {
-                // set the current composer to front right
+                    // set the current composer to right : margin
                     styles.right = margin;
                 
                 }else{
@@ -654,13 +662,14 @@ angular.module("proton.controllers.Compose", ["proton.constants"])
                         innerWindow = c.innerWindow,
                         overlap = c.overlap;
                         
-                        /* set styles */
+                        /* */
                         styles.right =  (overlap) ? (index*overlap) :  (index * (composerWidth) + (2*margin)),
                         styles.top = '';  
                 }
 
             }
 
+            /* Set the new styles */
             $(composer).css(styles);
 
         }, context);
@@ -806,7 +815,7 @@ angular.module("proton.controllers.Compose", ["proton.constants"])
             message.fields = true;
         }
 
-        $scope.composerStyle();
+        // $scope.composerStyle(); /*depreciated*/
     };
 
     $scope.showFields = function(message) {
@@ -1584,7 +1593,8 @@ angular.module("proton.controllers.Compose", ["proton.constants"])
     $scope.focusTo = function(message) {
         message.fields = true;
         $rootScope.$broadcast('squireHeightChanged');
-        $scope.composerStyle();
+        
+        // $scope.composerStyle(); /* depreciated */
         // Focus input
         $timeout(function() {
             $('#uid' + message.uid + ' .toRow input.new-value-email').focus();

--- a/src/app/controllers/compose.js
+++ b/src/app/controllers/compose.js
@@ -579,7 +579,7 @@ angular.module("proton.controllers.Compose", ["proton.constants"])
 
         // This timeout is really important to load the structure of Squire
         $timeout(function() {
-            $rootScope.$broadcast('squireHeightChanged');
+            // $rootScope.$broadcast('squireHeightChanged'); /* depreciated */
             $scope.composerStyle();
             // forward case: we need to save to get the attachments
             if(save === true) {
@@ -1592,13 +1592,14 @@ angular.module("proton.controllers.Compose", ["proton.constants"])
      */
     $scope.focusTo = function(message) {
         message.fields = true;
-        $rootScope.$broadcast('squireHeightChanged');
         
+        //$rootScope.$broadcast('squireHeightChanged'); /* depreciated */
         // $scope.composerStyle(); /* depreciated */
         // Focus input
+        
         $timeout(function() {
             $('#uid' + message.uid + ' .toRow input.new-value-email').focus();
-        });
+        }, 250);
     };
 
     $scope.focusNextInput = function(event) {

--- a/src/app/controllers/compose.js
+++ b/src/app/controllers/compose.js
@@ -609,7 +609,7 @@ angular.module("proton.controllers.Compose", ["proton.constants"])
         var composers = $('.composer'),
             environment = function() {
                 
-                if(composers.lenght === 0){ return; }
+                if(!composers){ return; }
 
                 var set = {};
 

--- a/src/app/controllers/compose.js
+++ b/src/app/controllers/compose.js
@@ -670,7 +670,9 @@ angular.module("proton.controllers.Compose", ["proton.constants"])
             }
 
             /* Set the new styles */
-            $(composer).css(styles);
+            $timeout(function() {
+                $(composer).css(styles);
+            },250);
 
         }, context);
     };


### PR DESCRIPTION
### Introduction

composerStyle() from composer contoller is used in

- onResize
- addAttachment
- initMessage
- toggleCcBcc
- close
- focusTo
- addAttachment

composerStyle() browse each .composer class to change the styles.

### Performance

**Expensive computation is performed in a loop. (225a425 + 79921e9)**

Implement environment() to compute outside _.each loop, and store the result inside a context variable. 

`_.each(composers, function(composer, index) { }, context);`

**Height depreciantion (a94cf49 + a844c92)**

As the height styling has been moved to a pure CSS solution :

- remove the height computation in the composerStyle()
- remove call to composerStyle() in addAttachment, toggleCcBcc, addAttachment, focusTo.
- squireHeightChanged events may be removed from initMessage and focusTo

### UX

**focusTo() (a844c92)**

Once the composer is loaded the editorLoaded event ask focusComposer (zIndex) to call focusTo (input focus).

The issue is that a timeout is setted at initMessage to wait the squire structure, so it break depending on the state time.

> e.g.
> Open a new composer, the focus is setted to input.new-value-email,
> Open a new composer, the focus is not setted to the focused composer. 

Add a timeout delay to the focus in focusTo() fixed it. 


**Blinking (faf3d7f)**

Once freshly added the composer have some blinking effects :

- Display recipient label, then change it for To.
- The composer blur class change, as a result it just blink.

Add a 250 delay to the styling to ensure computation is done before animation.

@EpokK 